### PR TITLE
Fix comments array initialization

### DIFF
--- a/util/extractor.py
+++ b/util/extractor.py
@@ -58,7 +58,7 @@ def extract_post_info(browser):
 
   # first element is the text, second either the first comment
   # or the button to display all the comments
-  comments = 0
+  comments = []
   tags = []
   if post.find_elements_by_tag_name('ul'):
     comment_list = post.find_element_by_tag_name('ul')


### PR DESCRIPTION
The variable comments is initialized as an int
````
comments = 0
````
which fails in the return if a post with no comments and no tags will fail to parse.
````
return img, tags, int(likes), int(len(comments) - 1)
````

The exception thrown is
````
Traceback (most recent call last):
  File "crawl_profile.py", line 27, in <module>
    information = extract_information(browser, username)
  File "_nstagram-profilecrawl/util/extractor.py", line 127, in extract_information
    img, tags, likes, comments = extract_post_info(browser)
  File "_/instagram-profilecrawl/util/extractor.py", line 80, in extract_post_info
    return img, tags, int(likes), int(len(comments) - 1)
TypeError: object of type 'int' has no len()
````