### PR TITLE
Update README: Copy chromedriver into ./assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It uses selenium to get all the information so install it with:
 pip install selenium
 ```
 
-Install the proper `chromedriver` for your operating system.  Once you (download it)[https://sites.google.com/a/chromium.org/chromedriver/downloads] just drag and drop it into the `instagram-profilecrawl` directory.
+Install the proper `chromedriver` for your operating system.  Once you (download it)[https://sites.google.com/a/chromium.org/chromedriver/downloads] just drag and drop it into `instagram-profilecrawl/assets` directory.
 
 ## Use it!
 Now you can start it using:


### PR DESCRIPTION
Copying chromedriver only into `instagram-profilecrawl` root, gave me errors (`chromedriver` wasn't found even when linked in PATH). I had to copy it into `instagram-profilecrawl/assets` (first creating the directory). I run Windows 10 64x.