### PR TITLE
Added script using Firefox for running on RPi

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ Now you can start it using:
 python3.5 crawl_profile.py username1 username2 ... usernameX
 ```
 
+### Run on Raspberry Pi
+To run the crawler on Raspberry Pi with Firefox, follow these steps:
+
+1. Install Firefox: `sudo apt-get install firefox-esr`
+2. Get the `geckodriver` as [described here](https://github.com/timgrossmann/InstaPy/blob/master/docs/How_to_Raspberry.md#how-to-update-geckodriver-on-raspbian)
+3. Install `pyvirtualdisplay`: `sudo pip3 install pyvirtualdisplay`
+4. Run the script for RPi: `python3 crawl_profile_pi.py username1 username2 ...`
+
 #### The information will be saved in a JSON-File in ./profiles/{username}.json.
 > Example of a files data
 ```

--- a/crawl_profile_pi.py
+++ b/crawl_profile_pi.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3.5
+
+# use this file for running on Raspberry Pi
+"""Goes through all usernames and collects their information"""
+import json
+from selenium import webdriver
+from pyvirtualdisplay import Display
+from util.cli_helper import get_all_user_names
+from util.extractor import extract_information
+
+
+display = Display(visible=0, size=(1024, 768))
+display.start()
+
+browser = webdriver.Firefox()
+
+# makes sure slower connections work as well        
+print ("Waiting 10 sec")
+browser.implicitly_wait(10)
+
+try:
+  usernames = get_all_user_names()
+
+  for username in usernames:
+    print('Extracting information from ' + username)
+    information, user_commented_list = extract_information(browser, username)
+
+    with open('./profiles/' + username + '.json', 'w') as fp:
+      json.dump(information, fp)
+
+    print ("Number of users who commented on his/her profile is ", len(user_commented_list),"\n")
+    file = open("./profiles/" + username + "_commenters.txt","w")
+    for line in user_commented_list:
+      file.write(line)
+      file.write("\n")
+    file.close()
+    print ("\nFinished. The json file and nicknames of users who commented were saved in profiles directory.\n")
+
+except KeyboardInterrupt:
+  print('Aborted...')
+
+finally:
+  browser.delete_all_cookies()
+  browser.close()
+  display.stop()


### PR DESCRIPTION
Since I'd like to run the crawler on my RPi 3, which does not have Chrome but Firefox, I added a slightly modified script for running Firefox instead of Chrome. I also added the steps for installation and usage in the Readme.

I just tested it on my Pi and it works.