### PR TITLE
Script for collecting and logging stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# ignore future changes to stats.csv
+stats.csv
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ For example, on Raspberry Pi run:
 1. Run `python3 crawl_profile_pi.py username`
 2. Run `python3 log_stats.py -u username`
 
-This appends the collected profile info to `stats.csv`. Can be useful for monitoring the development of an Instagram account over time.
+This appends the collected profile info to `stats.csv`. Can be useful for monitoring the growth of an Instagram account over time.
+The logged stats are: Time, username, total number of followers, following, posts, likes, and comments.
 The two commands can simply be triggered using `crontab` (make sure to trigger `log_stats.py` several minutes after `crawl_profile_pi.py`).
 
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ To run the crawler on Raspberry Pi with Firefox, follow these steps:
 3. Install `pyvirtualdisplay`: `sudo pip3 install pyvirtualdisplay`
 4. Run the script for RPi: `python3 crawl_profile_pi.py username1 username2 ...`
 
+**Collecting stats:**
+
+If you are interested in collecting and logging stats from a crawled profile, use the `log_stats.py` script *after* runnig `crawl_profile.py` (or `crawl_profile_pi.py`).
+For example, on Raspberry Pi run:
+
+1. Run `python3 crawl_profile_pi.py username`
+2. Run `python3 log_stats.py -u username`
+
+This appends the collected profile info to `stats.csv`. Can be useful for monitoring the development of an Instagram account over time.
+The two commands can simply be triggered using `crontab` (make sure to trigger `log_stats.py` several minutes after `crawl_profile_pi.py`).
+
+
 #### The information will be saved in a JSON-File in ./profiles/{username}.json.
 > Example of a files data
 ```

--- a/crawl_profile.py
+++ b/crawl_profile.py
@@ -13,7 +13,7 @@ chrome_options = Options()
 chrome_options.add_argument('--dns-prefetch-disable')
 chrome_options.add_argument('--no-sandbox')
 chrome_options.add_argument('--lang=en-US')
-#chrome_options.add_argument('--headless')
+chrome_options.add_argument('--headless')
 chrome_options.add_experimental_option('prefs', {'intl.accept_languages': 'en-US'})
 browser = webdriver.Chrome('./assets/chromedriver', chrome_options=chrome_options)
 

--- a/log_stats.py
+++ b/log_stats.py
@@ -1,0 +1,40 @@
+# simple module for reading crawled profile information and logging the stats
+import json
+import datetime
+import csv
+import argparse
+
+
+def log_stats(username):
+    profile_file = 'profiles/' + username + '.json'
+    with open(profile_file, 'r') as f_profile:
+        profile = json.load(f_profile)
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H:%M")
+
+        print('Reading crawled profile info of {}'.format(username))
+        print(profile)
+
+        # sum up likes and comments
+        likes = 0
+        comments = 0
+        for post in profile['posts']:
+            likes += post['likes']
+            comments += post['comments']
+
+        # append collected stats to stats.csv
+        with open('stats.csv', 'a', newline='') as f_stats:
+            writer = csv.writer(f_stats)
+            writer.writerow([timestamp, profile['username'], profile['followers'], profile['following'],
+                            profile['num_of_posts'], likes, comments])
+            print('Added stats to stats.csv')
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Read and log collected stats from crawled profiles")
+    parser.add_argument("-u", "--user", help="Username", required=True, default=None, dest="user")
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    args = parse_args()
+    log_stats(args.user)

--- a/stats.csv
+++ b/stats.csv
@@ -1,0 +1,1 @@
+timestamp,username,followers,following,posts,likes,comments


### PR DESCRIPTION
`log_stats.py` is a simple script that reads and logs stats from crawled profiles (`json` files). I use it for monitoring account growth over time. I thought it might be useful for others. If you don't feel it's useful for this repo, I'll just keep it on my own fork.

It doesn't affect the crawling functionality and can easily be automated using `crontab` (e.g., on RPi). I added a small section about in in the Readme.