### PR TITLE
Fixed likes retriving bug

### DIFF
--- a/util/extractor_posts.py
+++ b/util/extractor_posts.py
@@ -82,7 +82,6 @@ def extract_post_info(browser, postlink):
     if len(post.find_elements_by_tag_name('section')) > 2:
         likes = post.find_elements_by_tag_name('section')[1] \
             .find_element_by_tag_name('div').text
-
         likes = likes.split(' ')
 
         # count the names if there is no number displayed
@@ -94,6 +93,15 @@ def extract_post_info(browser, postlink):
             likes = likes.replace('k', '00')
         InstaLogger.logger().info("post-likes:" + likes)
 
+    #if likes is not known, it would cause errors to convert empty string to int
+
+    try:
+        likes = int(likes)
+    except Exception as err:
+        print ("Extracting number of likes failed. Saving likes as -1")
+        print (err)
+        likes = -1
+        
     user_comments = []
     user_commented_list = []
     mentions = []


### PR DESCRIPTION
Instagram is not showing likes if one is not logged in. Thus we cannot just try to get number of likes under the photo and convert it to int, we need to test if we can do it by using try, except error handling. Otherwise whole program throws error.

We will need to discuss if we want to allow user log in option for purpose of retrieving likes. If someone needs to get likes, I wrote how to do it by using cookie here: https://github.com/timgrossmann/instagram-profilecrawl/issues/108